### PR TITLE
fixed to correspond variety of include syntex formats

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ function getRequireDependencies(source, sourcePath) {
 
 function getEjsDependencies(source, sourcePath) {
     let dependecies = [];
-    const dependencyPattern = /<%[_\W]?\s*include((\(['"`](.*)['"`])|(\s+([^\s-]+)\s*[\W_]?%>))/g;
+    const dependencyPattern = /<%[_\W]?\s*include((\(['"`](\S+)['"`])|(\s+([^\s-]+)\s*[\W_]?%>))/g;
 
     let matches = dependencyPattern.exec(source);
     while (matches) {

--- a/test/fixtures/include-partials/index.ejs
+++ b/test/fixtures/include-partials/index.ejs
@@ -12,11 +12,24 @@
     <%- include('partials/nested-partial') %>
 
     <main>
+        <div class="iterate">
         <% for(let i = 0; i < 10; i++) { %>
             <%- include('partials/section', {
                 content: `Section: ${i + 1}`
             }) %>
         <% } %>
+        </div>
+        <div class="variable-formats">
+            <%- include('partials/section', {
+                content: `Section: Format 1`
+            }) %>
+            <%- include('partials/section', { content: `Section: Format 2` }) %>
+            <%- include('partials/section', { content:
+                `Section: Format 3` }) %>
+            <%- include('partials/section', {   
+                       content:    `Section: Format 4`   
+            }) %>
+        </div>
     </main>
 
     <%- include('partials/footer') %>

--- a/test/fixtures/include-partials/index.html
+++ b/test/fixtures/include-partials/index.html
@@ -16,16 +16,25 @@
 
 
     <main>
-        <section>Section: 1</section>
-        <section>Section: 2</section>
-        <section>Section: 3</section>
-        <section>Section: 4</section>
-        <section>Section: 5</section>
-        <section>Section: 6</section>
-        <section>Section: 7</section>
-        <section>Section: 8</section>
-        <section>Section: 9</section>
-        <section>Section: 10</section>
+        <div class="iterate">
+            <section>Section: 1</section>
+            <section>Section: 2</section>
+            <section>Section: 3</section>
+            <section>Section: 4</section>
+            <section>Section: 5</section>
+            <section>Section: 6</section>
+            <section>Section: 7</section>
+            <section>Section: 8</section>
+            <section>Section: 9</section>
+            <section>Section: 10</section>
+        </div>
+
+        <div class="variable-formats">
+            <section>Section: Format 1</section>
+            <section>Section: Format 2</section>
+            <section>Section: Format 3</section>
+            <section>Section: Format 4</section>
+        </div>
     </main>
 
     <footer>


### PR DESCRIPTION
Hi.

I found a bug of `include` syntax usage, that is like following:
`<%- include('partial/partial_example.ejs', { var: 'test' }) %>` as single line.

With above, webpack will dump an error for detecting a malformed requiring.  
```
Html Webpack Plugin:
  Error: Child compilation failed:
  Module build failed (from ./node_modules/ejs-plain-loader/lib/index.js):
  Error: ENOENT: no such file or directory, open '/Users/yabe/workspace/front_app/ejs/src/ejs/partial/partial_exampl  e.ejs', { var1: 'passed argument.ejs'
  
  - index.js:22 addDependencies
    [ejs]/[ejs-plain-loader]/lib/index.js:22:32

...
```

This is due to `dependencyPattern` lib used.
Please check test i edited.

> ofcource multiple lines had worked well, such as in the description in readme.